### PR TITLE
fixed proper makefile, will however need to make changes to offending line in local installation of sdl2.config.cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+
+build/**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,10 @@ project(CLionProject)
 set(CMAKE_CXX_STANDARD 11)
 
 set(SOURCE_FILES src/main.cpp src/game.cpp src/graphics.cpp headers/game.h headers/graphics.h src/main.cpp src/main.cpp)
-add_executable(CLionProject ${SOURCE_FILES})
 
+find_package(SDL2 REQUIRED)
+include_directories(${SDL2_INCLUDE_DIRS})
 
+add_executable(${PROJECT_NAME} ${SOURCE_FILES})
+
+target_link_libraries(${PROJECT_NAME} ${SDL2_LIBRARIES})

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1,5 +1,5 @@
 
-#include <SDL2/SDL.h>
+#include "SDL.h"
 
 #include "../headers/game.h"
 #include "../headers/graphics.h"


### PR DESCRIPTION
Commands (in terminal) to use when in root directory of project: 

"cmake ."

This one will probably complain about offending whitespace or similar. Google that problem and find a solution where some sdl2.config.cmake (something in that manner) is mentioned. Follow advice, and then cmake again. Now it should be working. Then use 

"make" // Create finale executable
"./CLionProject" // Run executable

Have not tried building with clion, but might work when you have followed this guide. 
